### PR TITLE
WIP: Wafersort CSR generator improvements

### DIFF
--- a/src/etched_peakrdl_cheader/csr_access_generator.py
+++ b/src/etched_peakrdl_cheader/csr_access_generator.py
@@ -129,6 +129,43 @@ class CsrAccessGenerator(RDLListener):
                 f"Unexpected regwidth of {node.size} for node {node.inst_name} | {self.get_struct_name(node)}"
             )
 
+    def get_ip_index(self, node: Node) -> str:
+        """Map CSR library prefix to IpIndex enum value for GPIO reporting."""
+        prefix = self.get_prefix(node).lower()
+
+        # IP index mapping based on CSR block prefix
+        ip_index_map = {
+            # Datalink blocks
+            "dlc_csr": "kDl",
+            "dl_dma_rf": "kDl",
+            "dl_bp_csr": "kDl",
+            "dl_ctl_top": "kDlCtl",
+            "datalink_pair_csr": "kDl",
+            "nlu_csr": "kDl",
+            # Compute blocks
+            "ipu_wrapper_csr": "kIpu",
+            "isc_csr": "kIsc",
+            "wcu_csr": "kWcu",
+            # SAU blocks
+            "sau_ctrl_csr": "kSau",
+            "samu_csr": "kSamu",
+            "samu_quad_wrapper_ctrl_csr": "kSamu",
+            # Peripherals
+            "gpio_addr_block": "kCsr",
+            "pcie_wrapper_csr": "kPcie",
+            "periph_ns_pad_csr": "kCsr",
+            # Ethernet (culpeo)
+            "culpeo": "kEth",
+        }
+
+        # Check for exact match first
+        for pattern, ip_index in ip_index_map.items():
+            if prefix.startswith(pattern):
+                return f"sival::wafersort::IpIndex::{ip_index}"
+
+        # Default to kCsr for unknown blocks
+        return "sival::wafersort::IpIndex::kCsr"
+
     def get_proper_size_from_128(self, node: RegNode, addr: str) -> str:
         if node.size == 32:  # 32 bytes = 256 bits
             return addr
@@ -398,6 +435,7 @@ class CsrAccessGenerator(RDLListener):
                 "field_bp": f"{field_prefix}_bp",
                 "field_bw": f"{field_prefix}_bw",
                 "test_idx": f"{hex(self.test_idx)}",
+                "ip_index": self.get_ip_index(node),
             }
             self.writeTestIdxMap(hex(self.test_idx), field)
 

--- a/src/etched_peakrdl_cheader/csr_access_generator.py
+++ b/src/etched_peakrdl_cheader/csr_access_generator.py
@@ -230,6 +230,58 @@ class CsrAccessGenerator(RDLListener):
 
         (fp, _) = self.stack.pop()
         addr_ptr = self.get_node_prefix(node) + "_addr"
+
+        fp.write(
+            f"void RunAll(sival::wafersort::TestRunner& runner, volatile {self.get_struct_name(node)} &{addr_ptr}) {{\n"
+        )
+        for child in node.children():
+            if child.ignore:
+                continue
+            if type(child) is SignalNode:
+                continue
+            if type(child) is AddrmapNode:
+                structmember = kwf(child.inst_name)
+                if child.is_array:
+                    for i in range(child.array_dimensions[0]):
+                        if i in child.ignore_idxes:
+                            continue
+                        fp.write(
+                            f"  {self.get_namespace_name(child)}::RunAll(runner, {addr_ptr}.{structmember}[{i}]);\n"
+                        )
+                else:
+                    fp.write(
+                        f"  {self.get_namespace_name(child)}::RunAll(runner, {addr_ptr}.{structmember});\n"
+                    )
+            if type(child) is RegNode:
+                addrptr = (
+                    f"reinterpret_cast<volatile __uint128_t*>(&{addr_ptr}.{kwf(child.inst_name)}"
+                )
+                if child.is_array:
+                    for i in range(child.array_dimensions[0]):
+                        if i in child.ignore_idxes:
+                            continue
+                        fp.write(
+                            f"  runner.Run([&]() {{ return {self.get_reg_test_name(child)}({addrptr}[{i}]), 0x0); }});\n"
+                        )
+                else:
+                    fp.write(
+                        f"  runner.Run([&]() {{ return {self.get_reg_test_name(child)}({addrptr}), 0x0); }});\n"
+                    )
+            if type(child) is RegfileNode:
+                structmember = kwf(child.inst_name)
+                if child.is_array:
+                    for i in range(child.array_dimensions[0]):
+                        if i in child.ignore_idxes:
+                            continue
+                        fp.write(
+                            f"  runner.Run([&]() {{ return {self.get_reg_test_name(child)}({addr_ptr}.{structmember}[{i}]); }});\n"
+                        )
+                else:
+                    fp.write(
+                        f"  runner.Run([&]() {{ return {self.get_reg_test_name(child)}({addr_ptr}.{structmember}); }});\n"
+                    )
+        fp.write("}\n\n")  # void RunAll
+
         fp.write(
             f"sival::wafersort::TestResult RwTest(volatile {self.get_struct_name(node)} &{addr_ptr}) {{\n"
         )

--- a/src/etched_peakrdl_cheader/csr_access_generator.py
+++ b/src/etched_peakrdl_cheader/csr_access_generator.py
@@ -134,6 +134,7 @@ class CsrAccessGenerator(RDLListener):
         prefix = self.get_prefix(node).lower()
 
         # IP index mapping based on CSR block prefix
+        # Note: Prefix comes from register node, not addrmap node
         ip_index_map = {
             # Datalink blocks
             "dlc_csr": "kDl",
@@ -142,13 +143,20 @@ class CsrAccessGenerator(RDLListener):
             "dl_ctl_top": "kDlCtl",
             "datalink_pair_csr": "kDl",
             "nlu_csr": "kDl",
-            # Compute blocks
+            "nlu_rf": "kDl",
+            # Compute blocks - register prefixes
             "ipu_wrapper_csr": "kIpu",
+            "ipu_rf": "kIpu",
             "isc_csr": "kIsc",
+            "isc_mem_rf": "kIsc",
             "wcu_csr": "kWcu",
+            "wcu_rf": "kWcu",
+            "wcu_quad_wrapper_ctrl_csr": "kWcu",
             # SAU blocks
             "sau_ctrl_csr": "kSau",
+            "sau_rf": "kSau",
             "samu_csr": "kSamu",
+            "samu_rf": "kSamu",
             "samu_quad_wrapper_ctrl_csr": "kSamu",
             # Peripherals
             "gpio_addr_block": "kCsr",

--- a/src/etched_peakrdl_cheader/csr_access_generator.py
+++ b/src/etched_peakrdl_cheader/csr_access_generator.py
@@ -341,8 +341,8 @@ class CsrAccessGenerator(RDLListener):
         curr_fp.write(
             f"sival::wafersort::TestResult {self.get_reg_test_name(node)}(volatile __uint128_t* {addr}) {{\n"
         )
-        curr_fp.write("  sival::wafersort::TestResult result = sival::wafersort::TestResult::Pass();\n\n")
 
+        # First pass: determine what kind of tests are needed
         mask_checks = []
         needs_check = False
         needs_readonly = False
@@ -361,8 +361,9 @@ class CsrAccessGenerator(RDLListener):
                 else:
                     needs_check = True
 
+        # Only declare result variable if there are testable R/W fields
         if needs_check:
-            pass  # No longer need curr_test_idx or ignorer - TestRunner handles progress
+            curr_fp.write("  sival::wafersort::TestResult result = sival::wafersort::TestResult::Pass();\n\n")
         if needs_readonly:
             curr_fp.write(self.get_full_mask_init(node, "read_only_mask"))
             mask_checks.append(

--- a/src/etched_peakrdl_cheader/csr_access_generator.py
+++ b/src/etched_peakrdl_cheader/csr_access_generator.py
@@ -231,9 +231,9 @@ class CsrAccessGenerator(RDLListener):
         (fp, _) = self.stack.pop()
         addr_ptr = self.get_node_prefix(node) + "_addr"
         fp.write(
-            f"bool RwTest(volatile {self.get_struct_name(node)} &{addr_ptr}, uint64_t test_idx) {{\n"
+            f"sival::wafersort::TestResult RwTest(volatile {self.get_struct_name(node)} &{addr_ptr}) {{\n"
         )
-        fp.write("  bool passed = true;\n")
+        fp.write("  sival::wafersort::TestResult result = sival::wafersort::TestResult::Pass();\n")
 
         for child in node.children():
             if child.ignore:
@@ -246,18 +246,15 @@ class CsrAccessGenerator(RDLListener):
                     for i in range(child.array_dimensions[0]):
                         if i in child.ignore_idxes:
                             continue
-                        fp.write("  if (passed) {\n")
                         fp.write(
-                            # f"    passed = {self.get_namespace_name(child)}::RwTest({addr_ptr}.{structmember}[{i}], test_idx | (uint64_t){hex(i)} << {(5 - (self.array_nest_lvl)) * 8});\n"
-                            f"    passed = {self.get_namespace_name(child)}::RwTest({addr_ptr}.{structmember}[{i}], test_idx);\n"
+                            f"  result = {self.get_namespace_name(child)}::RwTest({addr_ptr}.{structmember}[{i}]);\n"
                         )
-                        fp.write("  }\n")
+                        fp.write("  if (!result.passed) return result;\n")
                 else:
-                    fp.write("  if (passed) {\n")
                     fp.write(
-                        f"    {self.get_namespace_name(child)}::RwTest({addr_ptr}.{structmember}, test_idx);\n"
+                        f"  result = {self.get_namespace_name(child)}::RwTest({addr_ptr}.{structmember});\n"
                     )
-                    fp.write("  }\n")
+                    fp.write("  if (!result.passed) return result;\n")
             if (type(child) is RegNode) or (type(child) is RegfileNode):
                 addrptr = ""
                 if type(child) is RegNode:
@@ -269,20 +266,17 @@ class CsrAccessGenerator(RDLListener):
                         if i in child.ignore_idxes:
                             continue
 
-                        fp.write("  if (passed) {\n")
                         fp.write(
-                            # f"    passed &= {self.get_reg_test_name(child)}({addrptr}[{i}]), test_idx | (uint64_t){hex(i)} << {(5 - (self.array_nest_lvl)) * 8});\n"
-                            f"    passed &= {self.get_reg_test_name(child)}({addrptr}[{i}]), test_idx);\n"
+                            f"  result = {self.get_reg_test_name(child)}({addrptr}[{i}]));\n"
                         )
-                        fp.write("  }\n")
+                        fp.write("  if (!result.passed) return result;\n")
                 else:
-                    fp.write("  if (passed) {\n")
                     fp.write(
-                        f"    passed &= {self.get_reg_test_name(child)}({addrptr}), test_idx);\n"
+                        f"  result = {self.get_reg_test_name(child)}({addrptr}));\n"
                     )
-                    fp.write("  }\n")
-        fp.write("  return passed;\n")
-        fp.write("}\n")  # bool RwTest
+                    fp.write("  if (!result.passed) return result;\n")
+        fp.write("  return sival::wafersort::TestResult::Pass();\n")
+        fp.write("}\n")  # TestResult RwTest
 
         fp.write(f"}} // end {self.get_namespace_name(node)} namespace\n")
         fp.close()
@@ -305,9 +299,9 @@ class CsrAccessGenerator(RDLListener):
         if node.is_array:
             self.array_nest_lvl -= 1
         curr_fp.write(
-            f"bool {self.get_reg_test_name(node)}(volatile {self.get_struct_name(node)} &{addr_ptr}, uint64_t test_idx) {{\n"
+            f"sival::wafersort::TestResult {self.get_reg_test_name(node)}(volatile {self.get_struct_name(node)} &{addr_ptr}) {{\n"
         )
-        curr_fp.write("  bool passed = true;\n")
+        curr_fp.write("  sival::wafersort::TestResult result = sival::wafersort::TestResult::Pass();\n")
         for child in node.children():
             if child.ignore:
                 continue
@@ -323,19 +317,16 @@ class CsrAccessGenerator(RDLListener):
                     if i in child.ignore_idxes:
                         continue
 
-                    curr_fp.write("  if (passed) {\n")
                     curr_fp.write(
-                        # f"    passed &= {self.get_reg_test_name(child)}({addrptr}[{i}]), test_idx | (uint64_t){hex(i)} << {(5 - (self.array_nest_lvl)) * 8});\n"
-                        f"    passed &= {self.get_reg_test_name(child)}({addrptr}[{i}]), test_idx);\n"
+                        f"  result = {self.get_reg_test_name(child)}({addrptr}[{i}]));\n"
                     )
-                    curr_fp.write("  }\n")
+                    curr_fp.write("  if (!result.passed) return result;\n")
             else:
-                curr_fp.write("  if (passed) {\n")
                 curr_fp.write(
-                    f"    passed &= {self.get_reg_test_name(child)}({addrptr}), test_idx);\n"
+                    f"  result = {self.get_reg_test_name(child)}({addrptr}));\n"
                 )
-                curr_fp.write("  }\n")
-        curr_fp.write("  return passed;\n")
+                curr_fp.write("  if (!result.passed) return result;\n")
+        curr_fp.write("  return sival::wafersort::TestResult::Pass();\n")
         curr_fp.write("}\n")
         return WalkerAction.Continue
 
@@ -348,9 +339,9 @@ class CsrAccessGenerator(RDLListener):
 
         curr_fp.write(f"// {self.get_friendly_name(node)}\n")
         curr_fp.write(
-            f"bool {self.get_reg_test_name(node)}(volatile __uint128_t* {addr}, uint64_t test_idx) {{\n"
+            f"sival::wafersort::TestResult {self.get_reg_test_name(node)}(volatile __uint128_t* {addr}) {{\n"
         )
-        curr_fp.write("  bool passed = true;\n\n")
+        curr_fp.write("  sival::wafersort::TestResult result = sival::wafersort::TestResult::Pass();\n\n")
 
         mask_checks = []
         needs_check = False
@@ -371,10 +362,7 @@ class CsrAccessGenerator(RDLListener):
                     needs_check = True
 
         if needs_check:
-            curr_fp.write("  uint64_t curr_test_idx;\n")
-            curr_fp.write(
-                "  fw::app::csr_access_test::CsrTestIgnorer* ignorer = fw::app::csr_access_test::CsrTestIgnorer::GetCsrTestIgnorer();\n"
-            )
+            pass  # No longer need curr_test_idx or ignorer - TestRunner handles progress
         if needs_readonly:
             curr_fp.write(self.get_full_mask_init(node, "read_only_mask"))
             mask_checks.append(
@@ -453,7 +441,7 @@ class CsrAccessGenerator(RDLListener):
             curr_fp.write("\n\n")
         for mask_check in mask_checks:
             curr_fp.write(mask_check)
-        curr_fp.write("  return passed;\n")
+        curr_fp.write("  return sival::wafersort::TestResult::Pass();\n")
         curr_fp.write("}\n\n")  # RwTest
         return WalkerAction.SkipDescendants
 
@@ -475,12 +463,12 @@ class CsrAccessGenerator(RDLListener):
             if type(child) is RegfileNode:
                 childstk = list(child.children()) + childstk
                 header_fp.write(
-                    f"  bool {self.get_reg_test_name(child)}(volatile {self.get_struct_name(child)}&, uint64_t);\n"
+                    f"  sival::wafersort::TestResult {self.get_reg_test_name(child)}(volatile {self.get_struct_name(child)}&);\n"
                 )
                 continue
             if type(child) is RegNode:
                 header_fp.write(
-                    f"  bool {self.get_reg_test_name(child)}(volatile __uint128_t*, uint64_t);\n"
+                    f"  sival::wafersort::TestResult {self.get_reg_test_name(child)}(volatile __uint128_t*);\n"
                 )
         header_fp.write("}\n")
         header_fp.close()

--- a/src/etched_peakrdl_cheader/csr_access_generator.py
+++ b/src/etched_peakrdl_cheader/csr_access_generator.py
@@ -267,12 +267,12 @@ class CsrAccessGenerator(RDLListener):
                             continue
 
                         fp.write(
-                            f"  result = {self.get_reg_test_name(child)}({addrptr}[{i}]));\n"
+                            f"  result = {self.get_reg_test_name(child)}({addrptr}[{i}]), 0x0);\n"
                         )
                         fp.write("  if (!result.passed) return result;\n")
                 else:
                     fp.write(
-                        f"  result = {self.get_reg_test_name(child)}({addrptr}));\n"
+                        f"  result = {self.get_reg_test_name(child)}({addrptr}), 0x0);\n"
                     )
                     fp.write("  if (!result.passed) return result;\n")
         fp.write("  return sival::wafersort::TestResult::Pass();\n")
@@ -318,12 +318,12 @@ class CsrAccessGenerator(RDLListener):
                         continue
 
                     curr_fp.write(
-                        f"  result = {self.get_reg_test_name(child)}({addrptr}[{i}]));\n"
+                        f"  result = {self.get_reg_test_name(child)}({addrptr}[{i}]), 0x0);\n"
                     )
                     curr_fp.write("  if (!result.passed) return result;\n")
             else:
                 curr_fp.write(
-                    f"  result = {self.get_reg_test_name(child)}({addrptr}));\n"
+                    f"  result = {self.get_reg_test_name(child)}({addrptr}), 0x0);\n"
                 )
                 curr_fp.write("  if (!result.passed) return result;\n")
         curr_fp.write("  return sival::wafersort::TestResult::Pass();\n")
@@ -339,8 +339,10 @@ class CsrAccessGenerator(RDLListener):
 
         curr_fp.write(f"// {self.get_friendly_name(node)}\n")
         curr_fp.write(
-            f"sival::wafersort::TestResult {self.get_reg_test_name(node)}(volatile __uint128_t* {addr}) {{\n"
+            f"sival::wafersort::TestResult {self.get_reg_test_name(node)}(volatile __uint128_t* {addr}, uint64_t test_idx) {{\n"
         )
+        curr_fp.write("  auto ignorer = fw::app::csr_access_test::CsrTestIgnorer::GetCsrTestIgnorer();\n")
+        curr_fp.write("  uint64_t curr_test_idx = 0;\n")
 
         # First pass: determine what kind of tests are needed
         mask_checks = []
@@ -469,7 +471,7 @@ class CsrAccessGenerator(RDLListener):
                 continue
             if type(child) is RegNode:
                 header_fp.write(
-                    f"  sival::wafersort::TestResult {self.get_reg_test_name(child)}(volatile __uint128_t*);\n"
+                    f"  sival::wafersort::TestResult {self.get_reg_test_name(child)}(volatile __uint128_t*, uint64_t);\n"
                 )
         header_fp.write("}\n")
         header_fp.close()

--- a/src/etched_peakrdl_cheader/csr_access_generator.py
+++ b/src/etched_peakrdl_cheader/csr_access_generator.py
@@ -234,6 +234,9 @@ class CsrAccessGenerator(RDLListener):
             f"sival::wafersort::TestResult RwTest(volatile {self.get_struct_name(node)} &{addr_ptr}) {{\n"
         )
         fp.write("  sival::wafersort::TestResult result = sival::wafersort::TestResult::Pass();\n")
+        fp.write(
+            "  sival::wafersort::TestResult first_failure = sival::wafersort::TestResult::Pass();\n"
+        )
 
         for child in node.children():
             if child.ignore:
@@ -249,18 +252,20 @@ class CsrAccessGenerator(RDLListener):
                         fp.write(
                             f"  result = {self.get_namespace_name(child)}::RwTest({addr_ptr}.{structmember}[{i}]);\n"
                         )
-                        fp.write("  if (!result.passed) return result;\n")
+                        fp.write(
+                            "  if (!result.passed && first_failure.passed) first_failure = result;\n"
+                        )
                 else:
                     fp.write(
                         f"  result = {self.get_namespace_name(child)}::RwTest({addr_ptr}.{structmember});\n"
                     )
-                    fp.write("  if (!result.passed) return result;\n")
-            if (type(child) is RegNode) or (type(child) is RegfileNode):
-                addrptr = ""
-                if type(child) is RegNode:
-                    addrptr = f"reinterpret_cast<volatile __uint128_t*>(&{addr_ptr}.{child.inst_name}"
-                else:
-                    addrptr = f"({addr_ptr}.{child.inst_name}"
+                    fp.write(
+                        "  if (!result.passed && first_failure.passed) first_failure = result;\n"
+                    )
+            if type(child) is RegNode:
+                addrptr = (
+                    f"reinterpret_cast<volatile __uint128_t*>(&{addr_ptr}.{kwf(child.inst_name)}"
+                )
                 if child.is_array:
                     for i in range(child.array_dimensions[0]):
                         if i in child.ignore_idxes:
@@ -269,13 +274,36 @@ class CsrAccessGenerator(RDLListener):
                         fp.write(
                             f"  result = {self.get_reg_test_name(child)}({addrptr}[{i}]), 0x0);\n"
                         )
-                        fp.write("  if (!result.passed) return result;\n")
+                        fp.write(
+                            "  if (!result.passed && first_failure.passed) first_failure = result;\n"
+                        )
                 else:
                     fp.write(
                         f"  result = {self.get_reg_test_name(child)}({addrptr}), 0x0);\n"
                     )
-                    fp.write("  if (!result.passed) return result;\n")
-        fp.write("  return sival::wafersort::TestResult::Pass();\n")
+                    fp.write(
+                        "  if (!result.passed && first_failure.passed) first_failure = result;\n"
+                    )
+            if type(child) is RegfileNode:
+                structmember = kwf(child.inst_name)
+                if child.is_array:
+                    for i in range(child.array_dimensions[0]):
+                        if i in child.ignore_idxes:
+                            continue
+                        fp.write(
+                            f"  result = {self.get_reg_test_name(child)}({addr_ptr}.{structmember}[{i}]);\n"
+                        )
+                        fp.write(
+                            "  if (!result.passed && first_failure.passed) first_failure = result;\n"
+                        )
+                else:
+                    fp.write(
+                        f"  result = {self.get_reg_test_name(child)}({addr_ptr}.{structmember});\n"
+                    )
+                    fp.write(
+                        "  if (!result.passed && first_failure.passed) first_failure = result;\n"
+                    )
+        fp.write("  return first_failure;\n")
         fp.write("}\n")  # TestResult RwTest
 
         fp.write(f"}} // end {self.get_namespace_name(node)} namespace\n")
@@ -302,31 +330,56 @@ class CsrAccessGenerator(RDLListener):
             f"sival::wafersort::TestResult {self.get_reg_test_name(node)}(volatile {self.get_struct_name(node)} &{addr_ptr}) {{\n"
         )
         curr_fp.write("  sival::wafersort::TestResult result = sival::wafersort::TestResult::Pass();\n")
+        curr_fp.write(
+            "  sival::wafersort::TestResult first_failure = sival::wafersort::TestResult::Pass();\n"
+        )
         for child in node.children():
             if child.ignore:
                 continue
             if type(child) is SignalNode:
                 continue
-            addrptr = ""
             if type(child) is RegNode:
-                addrptr = f"reinterpret_cast<volatile __uint128_t*>(&{addr_ptr}.{child.inst_name}"
-            else:
-                addrptr = f"({addr_ptr}.{child.inst_name}"
-            if child.is_array:
-                for i in range(child.array_dimensions[0]):
-                    if i in child.ignore_idxes:
-                        continue
-
-                    curr_fp.write(
-                        f"  result = {self.get_reg_test_name(child)}({addrptr}[{i}]), 0x0);\n"
-                    )
-                    curr_fp.write("  if (!result.passed) return result;\n")
-            else:
-                curr_fp.write(
-                    f"  result = {self.get_reg_test_name(child)}({addrptr}), 0x0);\n"
+                addrptr = (
+                    f"reinterpret_cast<volatile __uint128_t*>(&{addr_ptr}.{kwf(child.inst_name)}"
                 )
-                curr_fp.write("  if (!result.passed) return result;\n")
-        curr_fp.write("  return sival::wafersort::TestResult::Pass();\n")
+                if child.is_array:
+                    for i in range(child.array_dimensions[0]):
+                        if i in child.ignore_idxes:
+                            continue
+
+                        curr_fp.write(
+                            f"  result = {self.get_reg_test_name(child)}({addrptr}[{i}]), 0x0);\n"
+                        )
+                        curr_fp.write(
+                            "  if (!result.passed && first_failure.passed) first_failure = result;\n"
+                        )
+                else:
+                    curr_fp.write(
+                        f"  result = {self.get_reg_test_name(child)}({addrptr}), 0x0);\n"
+                    )
+                    curr_fp.write(
+                        "  if (!result.passed && first_failure.passed) first_failure = result;\n"
+                    )
+            if type(child) is RegfileNode:
+                structmember = kwf(child.inst_name)
+                if child.is_array:
+                    for i in range(child.array_dimensions[0]):
+                        if i in child.ignore_idxes:
+                            continue
+                        curr_fp.write(
+                            f"  result = {self.get_reg_test_name(child)}({addr_ptr}.{structmember}[{i}]);\n"
+                        )
+                        curr_fp.write(
+                            "  if (!result.passed && first_failure.passed) first_failure = result;\n"
+                        )
+                else:
+                    curr_fp.write(
+                        f"  result = {self.get_reg_test_name(child)}({addr_ptr}.{structmember});\n"
+                    )
+                    curr_fp.write(
+                        "  if (!result.passed && first_failure.passed) first_failure = result;\n"
+                    )
+        curr_fp.write("  return first_failure;\n")
         curr_fp.write("}\n")
         return WalkerAction.Continue
 
@@ -343,6 +396,8 @@ class CsrAccessGenerator(RDLListener):
         )
         curr_fp.write("  auto ignorer = fw::app::csr_access_test::CsrTestIgnorer::GetCsrTestIgnorer();\n")
         curr_fp.write("  uint64_t curr_test_idx = 0;\n")
+        curr_fp.write("  (void)ignorer;\n")
+        curr_fp.write("  (void)curr_test_idx;\n")
 
         # First pass: determine what kind of tests are needed
         mask_checks = []
@@ -365,7 +420,12 @@ class CsrAccessGenerator(RDLListener):
 
         # Only declare result variable if there are testable R/W fields
         if needs_check:
-            curr_fp.write("  sival::wafersort::TestResult result = sival::wafersort::TestResult::Pass();\n\n")
+            curr_fp.write(
+                "  sival::wafersort::TestResult result = sival::wafersort::TestResult::Pass();\n"
+            )
+            curr_fp.write(
+                "  sival::wafersort::TestResult first_failure = sival::wafersort::TestResult::Pass();\n\n"
+            )
         if needs_readonly:
             curr_fp.write(self.get_full_mask_init(node, "read_only_mask"))
             mask_checks.append(
@@ -444,7 +504,10 @@ class CsrAccessGenerator(RDLListener):
             curr_fp.write("\n\n")
         for mask_check in mask_checks:
             curr_fp.write(mask_check)
-        curr_fp.write("  return sival::wafersort::TestResult::Pass();\n")
+        if needs_check:
+            curr_fp.write("  return first_failure;\n")
+        else:
+            curr_fp.write("  return sival::wafersort::TestResult::Pass();\n")
         curr_fp.write("}\n\n")  # RwTest
         return WalkerAction.SkipDescendants
 

--- a/src/etched_peakrdl_cheader/csr_lib_splitter.py
+++ b/src/etched_peakrdl_cheader/csr_lib_splitter.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# Functions that wrap/dispatch to other test functions. These are excluded when
+# creating split libraries since they would pull in many other functions.
+_WRAPPER_FUNCTIONS = {
+    "RwTest",
+    "TsRwTest",
+    "IscTimestampRwTest",
+    "ControlRwTest",
+}
+
+
+def split_default_wafersort_libs(out_dir: str) -> None:
+    """Split known-bloated wafersort CSR test libraries by bitfield count."""
+    out_path = Path(out_dir)
+    _split_single_library_by_bitfields(out_path, "dl_bp_csr_rw_test_lib", 8)
+    _split_single_library_by_bitfields(out_path, "dl_ctl_top_rw_test_lib", 4)
+    _split_isc_csr(out_path)
+
+
+def split_libraries_by_bitfields(out_dir: str, split_rules: dict[str, int]) -> None:
+    """Split generated CSR test libs into *_partN libs balancing bitfield tests.
+
+    This is a post-processing step on generated .cc/.h files. It partitions
+    leaf register-test functions across N parts using a greedy algorithm based
+    on the number of BitFieldWriteReadTest* calls per function.
+    """
+    out_path = Path(out_dir)
+    for lib_name, num_parts in split_rules.items():
+        if num_parts <= 1:
+            continue
+        _split_single_library_by_bitfields(out_path, lib_name, num_parts)
+
+
+def _split_isc_csr(out_dir: Path) -> None:
+    """Keep isc_csr split stable for existing wafersort test apps."""
+    lib_name = "isc_csr_rw_test_lib"
+    cc_path = out_dir / f"{lib_name}.cc"
+    h_path = out_dir / f"{lib_name}.h"
+    if not cc_path.exists() or not h_path.exists():
+        return
+
+    functions = _parse_cc_for_function_bodies(cc_path)
+    functions = {
+        name: body for name, body in functions.items() if name not in _WRAPPER_FUNCTIONS
+    }
+    if not functions:
+        return
+
+    header_text, namespace_name = _extract_header_and_namespace(cc_path)
+    decls = _parse_header_declarations(h_path)
+
+    part1 = [
+        "Desc0RwTest",
+        "Desc1RwTest",
+        "IntcRwTest",
+        "SaColRwTest",
+        "MemoryControlRwTest",
+        "AxiSettingRwTest",
+    ] + [f"Start{i}IscTimestampRwTest" for i in range(26)]
+
+    part2 = [f"Start{i}IscTimestampRwTest" for i in range(26, 32)] + [
+        f"Done{i}IscTimestampRwTest" for i in range(31)
+    ]
+
+    part3 = [
+        "Done31IscTimestampRwTest",
+        "GlobalEnableIscTimestampRwTest",
+        "LocalControlIscTimestampRwTest",
+    ]
+
+    _split_single_library_fixed_parts(
+        out_dir,
+        lib_name,
+        namespace_name,
+        header_text,
+        functions,
+        decls,
+        [part1, part2, part3],
+    )
+
+
+def _split_single_library_by_bitfields(out_dir: Path, lib_name: str, num_parts: int) -> None:
+    cc_path = out_dir / f"{lib_name}.cc"
+    h_path = out_dir / f"{lib_name}.h"
+    if not cc_path.exists() or not h_path.exists():
+        return
+
+    functions = _parse_cc_for_function_bodies(cc_path)
+    functions = {
+        name: body for name, body in functions.items() if name not in _WRAPPER_FUNCTIONS
+    }
+    if not functions:
+        return
+
+    header_text, namespace_name = _extract_header_and_namespace(cc_path)
+    decls = _parse_header_declarations(h_path)
+
+    func_bitfields = {name: _count_bitfields(body) for name, body in functions.items()}
+
+    # Stable sort: ties preserve original file order since dicts preserve
+    # insertion order and Python's sort is stable.
+    sorted_funcs = sorted(func_bitfields.keys(), key=lambda x: -func_bitfields[x])
+
+    parts: list[list[str]] = [[] for _ in range(num_parts)]
+    part_totals = [0] * num_parts
+
+    for func_name in sorted_funcs:
+        min_idx = part_totals.index(min(part_totals))
+        parts[min_idx].append(func_name)
+        part_totals[min_idx] += func_bitfields[func_name]
+
+    for part_idx, part_funcs in enumerate(parts):
+        if not part_funcs:
+            continue
+        split_name = f"{lib_name}_part{part_idx + 1}"
+        _write_part_header(out_dir, split_name, namespace_name, part_idx + 1, part_funcs, decls)
+        _write_part_cc(
+            out_dir,
+            split_name,
+            lib_name,
+            namespace_name,
+            part_idx + 1,
+            header_text,
+            functions,
+            part_funcs,
+        )
+
+
+def _split_single_library_fixed_parts(
+    out_dir: Path,
+    lib_name: str,
+    namespace_name: str,
+    header_text: str,
+    functions: dict[str, str],
+    decls: dict[str, str],
+    parts: list[list[str]],
+) -> None:
+    for part_idx, part_funcs in enumerate(parts):
+        filtered_funcs = [name for name in part_funcs if name in functions]
+        if not filtered_funcs:
+            continue
+        split_name = f"{lib_name}_part{part_idx + 1}"
+        _write_part_header(
+            out_dir,
+            split_name,
+            namespace_name,
+            part_idx + 1,
+            filtered_funcs,
+            decls,
+        )
+        _write_part_cc(
+            out_dir,
+            split_name,
+            lib_name,
+            namespace_name,
+            part_idx + 1,
+            header_text,
+            functions,
+            filtered_funcs,
+        )
+
+
+def _count_bitfields(func_body: str) -> int:
+    return func_body.count("BitFieldWriteReadTest")
+
+
+def _parse_header_declarations(header_path: Path) -> dict[str, str]:
+    content = header_path.read_text()
+
+    decl_pattern = re.compile(
+        r"(sival::wafersort::TestResult\s+(\w+)\s*\([^;]+\);)",
+        re.MULTILINE | re.DOTALL,
+    )
+
+    decls: dict[str, str] = {}
+    for match in decl_pattern.finditer(content):
+        full_decl = match.group(1).strip()
+        func_name = match.group(2)
+        decls[func_name] = full_decl
+
+    return decls
+
+
+def _parse_cc_for_function_bodies(cc_path: Path) -> dict[str, str]:
+    content = cc_path.read_text()
+    functions: dict[str, str] = {}
+
+    lines = content.split("\n")
+    current_func: str | None = None
+    func_lines: list[str] = []
+    brace_count = 0
+    in_function = False
+
+    func_start_pattern = re.compile(r"^sival::wafersort::TestResult\s+(\w+)\s*\(")
+
+    for line in lines:
+        match = func_start_pattern.match(line)
+        if match and not in_function:
+            current_func = match.group(1)
+            func_lines = [line]
+            brace_count = line.count("{") - line.count("}")
+            in_function = brace_count > 0 or "{" not in line
+            continue
+
+        if in_function:
+            func_lines.append(line)
+            brace_count += line.count("{") - line.count("}")
+
+            if brace_count == 0 and "{" in "".join(func_lines):
+                if current_func is not None:
+                    functions[current_func] = "\n".join(func_lines)
+                current_func = None
+                func_lines = []
+                in_function = False
+
+    return functions
+
+
+def _extract_header_and_namespace(cc_path: Path) -> tuple[str, str]:
+    content = cc_path.read_text()
+    lines = content.split("\n")
+
+    header_lines: list[str] = []
+    namespace_name: str | None = None
+    in_multiline_macro = False
+
+    for line in lines:
+        if in_multiline_macro:
+            header_lines.append(line)
+            if not line.rstrip().endswith("\\"):
+                in_multiline_macro = False
+            continue
+
+        if (
+            line.startswith("#include")
+            or line.startswith("#ifndef")
+            or line.startswith("#ifdef")
+            or line.startswith("#define")
+            or line.startswith("#else")
+            or line.startswith("#endif")
+            or line.strip() == ""
+            or line.startswith("//")
+        ):
+            header_lines.append(line)
+            if line.rstrip().endswith("\\"):
+                in_multiline_macro = True
+            continue
+
+        match = re.match(r"^namespace\s+(\w+)\s*\{", line)
+        if match:
+            namespace_name = match.group(1)
+            break
+
+    if namespace_name is None:
+        raise ValueError(f"Failed to find namespace in {cc_path}")
+
+    header_text = "\n".join(header_lines)
+    return header_text, namespace_name
+
+
+def _write_part_header(
+    out_dir: Path,
+    split_name: str,
+    namespace_name: str,
+    part_num: int,
+    part_funcs: list[str],
+    decls: dict[str, str],
+) -> None:
+    out_path = out_dir / f"{split_name}.h"
+    part_namespace = f"{namespace_name}Part{part_num}"
+
+    decl_lines: list[str] = []
+    for func_name in part_funcs:
+        decl = decls.get(func_name)
+        if decl is None:
+            raise ValueError(
+                f"Missing declaration for {func_name} in {split_name}.h"
+            )
+        decl_lines.append(decl)
+
+    content = (
+        "#pragma once\n\n"
+        "#include <cstdint>\n\n"
+        '#include "fw/soc/sohu/sohu_chip_csr.h"\n'
+        '#include "sival/wafersort/sival_helper.h"\n\n'
+        f"namespace {part_namespace} {{\n"
+        + "\n".join(decl_lines)
+        + f"\n}}  // namespace {part_namespace}\n"
+    )
+
+    out_path.write_text(content)
+
+
+def _write_part_cc(
+    out_dir: Path,
+    split_name: str,
+    lib_name: str,
+    namespace_name: str,
+    part_num: int,
+    header_text: str,
+    functions: dict[str, str],
+    part_funcs: list[str],
+) -> None:
+    out_path = out_dir / f"{split_name}.cc"
+    part_namespace = f"{namespace_name}Part{part_num}"
+
+    new_header = header_text.replace(
+        f'#include "{lib_name}.h"', f'#include "{split_name}.h"'
+    )
+
+    body = "\n\n".join(functions[func_name] for func_name in part_funcs)
+    content = (
+        f"{new_header}\n"
+        f"namespace {part_namespace} {{\n\n"
+        f"{body}\n\n"
+        f"}}  // namespace {part_namespace}\n"
+    )
+
+    out_path.write_text(content)

--- a/src/etched_peakrdl_cheader/exporter.py
+++ b/src/etched_peakrdl_cheader/exporter.py
@@ -12,6 +12,7 @@ from .directive_injector import DirectiveInjector
 from .nodename_retriever import NodenameRetriever
 from .unique_rebuild_directive_injector import UniqueRebuildDirectiveInjector
 from .csr_access_generator import CsrAccessGenerator
+from .csr_lib_splitter import split_default_wafersort_libs
 
 
 class CHeaderExporter:
@@ -43,6 +44,9 @@ class CHeaderExporter:
 
         print("Generating files...")
         CsrAccessGenerator(ds).run(out_dir, top_node)
+
+        print("Splitting large CSR test libraries...")
+        split_default_wafersort_libs(out_dir)
 
         print("Clang-formatting files...")
         files = glob.glob(os.path.join(out_dir, "*.cc"))

--- a/src/etched_peakrdl_cheader/templates/BUILD_TEMPLATE
+++ b/src/etched_peakrdl_cheader/templates/BUILD_TEMPLATE
@@ -2,7 +2,8 @@ cc_library(
     name = "{{name}}",
     srcs = ["{{srcs}}"],
     hdrs = ["{{hdrs}}"],
-    visibility = ["//fw:__subpackages__"],
+    defines = ["ENABLE_LOGGING"],
+    visibility = ["//sival:__subpackages__"],
     deps = [{% for dep in impl_deps %}
         "{{dep}}",{% endfor %}
         "//fw/app/csr_access_test:csr_test_ignorer",
@@ -10,6 +11,7 @@ cc_library(
         "//fw/testing:bit_field_test",
         "//fw/testing:testing",
         "//fw/utils:csr_descriptor_helper",
+        "//sival/wafersort:sival_helper",
     ],
 )
 

--- a/src/etched_peakrdl_cheader/templates/BUILD_TEMPLATE
+++ b/src/etched_peakrdl_cheader/templates/BUILD_TEMPLATE
@@ -2,7 +2,10 @@ cc_library(
     name = "{{name}}",
     srcs = ["{{srcs}}"],
     hdrs = ["{{hdrs}}"],
-    defines = ["ENABLE_LOGGING"],
+    local_defines = [
+        "ENABLE_WAFERSORT_GPIO",
+        "ENABLE_LOGGING",
+    ],
     visibility = ["//sival:__subpackages__"],
     deps = [{% for dep in impl_deps %}
         "{{dep}}",{% endfor %}
@@ -11,8 +14,8 @@ cc_library(
         "//fw/testing:bit_field_test",
         "//fw/testing:testing",
         "//fw/utils:csr_descriptor_helper",
-        "//sival/wafersort:sival_helper",
+        "//fw/utils:log",
+        "//sival/wafersort/csr:csr_test_utils",
     ],
 )
-
 

--- a/src/etched_peakrdl_cheader/templates/rw_readwrite_test.c
+++ b/src/etched_peakrdl_cheader/templates/rw_readwrite_test.c
@@ -35,7 +35,12 @@
 #endif
 {% endif %}
     if (!result.passed) {
-      return result;
+      // Report failure but continue running remaining fields.
+      result.reported = true;
+      sival::wafersort::TestCsrSramStatusGpio128(true, result.ip_index,
+                                                 result.address, result.data);
+      if (first_failure.passed) {
+        first_failure = result;
+      }
     }
   }
-

--- a/src/etched_peakrdl_cheader/templates/rw_readwrite_test.c
+++ b/src/etched_peakrdl_cheader/templates/rw_readwrite_test.c
@@ -3,10 +3,14 @@
   if(!ignorer->ShouldSkipTestIndex(curr_test_idx)) {
 #ifdef ENABLE_WAFERSORT_GPIO
     sival::wafersort::TestProgressGpio(curr_test_idx & 0xFF);
+    WS_LOG_INFO("Testing {{field}} (0x%llx)", (unsigned long long)curr_test_idx);
 #endif
     passed = fw::testing::{{function_name}}({{reg_ptr}},
                         {{field_bp}},
                         {{field_bw}});
+#ifdef ENABLE_WAFERSORT_GPIO
+    WS_LOG_INFO("  %s", passed ? "PASS" : "FAIL");
+#endif
   }
   if (!passed) {
     fw::testing::TestFail((uint64_t)0xDEAD000000000000 | curr_test_idx);

--- a/src/etched_peakrdl_cheader/templates/rw_readwrite_test.c
+++ b/src/etched_peakrdl_cheader/templates/rw_readwrite_test.c
@@ -2,17 +2,51 @@
   curr_test_idx = (uint64_t)test_idx | (uint64_t){{test_idx}};
   if(!ignorer->ShouldSkipTestIndex(curr_test_idx)) {
 #ifdef ENABLE_WAFERSORT_GPIO
-    sival::wafersort::TestProgressGpio(curr_test_idx & 0xFF);
-    WS_LOG_INFO("Testing {{field}} (0x%llx)", (unsigned long long)curr_test_idx);
+{% if function_name == "BitFieldWriteReadTest256" %}
+#ifndef ENABLE_LOGGING
+    passed = sival::wafersort::csr::BitFieldWriteReadTest256WithReport(
+        {{reg_ptr}},
+        {{field_bp}},
+        {{field_bw}},
+        curr_test_idx,
+        nullptr);
+#else
+    passed = sival::wafersort::csr::BitFieldWriteReadTest256WithReport(
+        {{reg_ptr}},
+        {{field_bp}},
+        {{field_bw}},
+        curr_test_idx,
+        "{{field}}");
 #endif
+{% else %}
+#ifndef ENABLE_LOGGING
+    passed = sival::wafersort::csr::BitFieldWriteReadTest32WithReport(
+        {{reg_ptr}},
+        {{field_bp}},
+        {{field_bw}},
+        curr_test_idx,
+        nullptr);
+#else
+    passed = sival::wafersort::csr::BitFieldWriteReadTest32WithReport(
+        {{reg_ptr}},
+        {{field_bp}},
+        {{field_bw}},
+        curr_test_idx,
+        "{{field}}");
+#endif
+{% endif %}
+#else
+    WS_LOG_INFO("Testing {{field}} (0x%llx)",
+                (unsigned long long)curr_test_idx);
     passed = fw::testing::{{function_name}}({{reg_ptr}},
                         {{field_bp}},
                         {{field_bw}});
-#ifdef ENABLE_WAFERSORT_GPIO
     WS_LOG_INFO("  %s", passed ? "PASS" : "FAIL");
 #endif
   }
   if (!passed) {
+#ifndef ENABLE_WAFERSORT_GPIO
     fw::testing::TestFail((uint64_t)0xDEAD000000000000 | curr_test_idx);
+#endif
     return false;
   }

--- a/src/etched_peakrdl_cheader/templates/rw_readwrite_test.c
+++ b/src/etched_peakrdl_cheader/templates/rw_readwrite_test.c
@@ -9,14 +9,16 @@
         {{field_bp}},
         {{field_bw}},
         curr_test_idx,
-        nullptr);
+        nullptr,
+        {{ip_index}});
 #else
     passed = sival::wafersort::csr::BitFieldWriteReadTest256WithReport(
         {{reg_ptr}},
         {{field_bp}},
         {{field_bw}},
         curr_test_idx,
-        "{{field}}");
+        "{{field}}",
+        {{ip_index}});
 #endif
 {% else %}
 #ifndef ENABLE_LOGGING
@@ -25,14 +27,16 @@
         {{field_bp}},
         {{field_bw}},
         curr_test_idx,
-        nullptr);
+        nullptr,
+        {{ip_index}});
 #else
     passed = sival::wafersort::csr::BitFieldWriteReadTest32WithReport(
         {{reg_ptr}},
         {{field_bp}},
         {{field_bw}},
         curr_test_idx,
-        "{{field}}");
+        "{{field}}",
+        {{ip_index}});
 #endif
 {% endif %}
 #else

--- a/src/etched_peakrdl_cheader/templates/rw_readwrite_test.c
+++ b/src/etched_peakrdl_cheader/templates/rw_readwrite_test.c
@@ -1,38 +1,41 @@
   // Write-Read from {{field}} bit field
+  curr_test_idx = (uint64_t)test_idx | (uint64_t){{test_idx}};
+  if (!ignorer->ShouldSkipTestIndex(curr_test_idx)) {
 {% if function_name == "BitFieldWriteReadTest256" %}
 #ifndef ENABLE_LOGGING
-  result = sival::wafersort::csr::BitFieldWriteReadTest256(
-      {{reg_ptr}},
-      {{field_bp}},
-      {{field_bw}},
-      nullptr,
-      {{ip_index}});
+    result = sival::wafersort::csr::BitFieldWriteReadTest256(
+        {{reg_ptr}},
+        {{field_bp}},
+        {{field_bw}},
+        nullptr,
+        {{ip_index}});
 #else
-  result = sival::wafersort::csr::BitFieldWriteReadTest256(
-      {{reg_ptr}},
-      {{field_bp}},
-      {{field_bw}},
-      "{{field}}",
-      {{ip_index}});
+    result = sival::wafersort::csr::BitFieldWriteReadTest256(
+        {{reg_ptr}},
+        {{field_bp}},
+        {{field_bw}},
+        "{{field}}",
+        {{ip_index}});
 #endif
 {% else %}
 #ifndef ENABLE_LOGGING
-  result = sival::wafersort::csr::BitFieldWriteReadTest32(
-      {{reg_ptr}},
-      {{field_bp}},
-      {{field_bw}},
-      nullptr,
-      {{ip_index}});
+    result = sival::wafersort::csr::BitFieldWriteReadTest32(
+        {{reg_ptr}},
+        {{field_bp}},
+        {{field_bw}},
+        nullptr,
+        {{ip_index}});
 #else
-  result = sival::wafersort::csr::BitFieldWriteReadTest32(
-      {{reg_ptr}},
-      {{field_bp}},
-      {{field_bw}},
-      "{{field}}",
-      {{ip_index}});
+    result = sival::wafersort::csr::BitFieldWriteReadTest32(
+        {{reg_ptr}},
+        {{field_bp}},
+        {{field_bw}},
+        "{{field}}",
+        {{ip_index}});
 #endif
 {% endif %}
-  if (!result.passed) {
-    return result;
+    if (!result.passed) {
+      return result;
+    }
   }
 

--- a/src/etched_peakrdl_cheader/templates/rw_readwrite_test.c
+++ b/src/etched_peakrdl_cheader/templates/rw_readwrite_test.c
@@ -1,56 +1,38 @@
   // Write-Read from {{field}} bit field
-  curr_test_idx = (uint64_t)test_idx | (uint64_t){{test_idx}};
-  if(!ignorer->ShouldSkipTestIndex(curr_test_idx)) {
-#ifdef ENABLE_WAFERSORT_GPIO
 {% if function_name == "BitFieldWriteReadTest256" %}
 #ifndef ENABLE_LOGGING
-    passed = sival::wafersort::csr::BitFieldWriteReadTest256WithReport(
-        {{reg_ptr}},
-        {{field_bp}},
-        {{field_bw}},
-        curr_test_idx,
-        nullptr,
-        {{ip_index}});
+  result = sival::wafersort::csr::BitFieldWriteReadTest256(
+      {{reg_ptr}},
+      {{field_bp}},
+      {{field_bw}},
+      nullptr,
+      {{ip_index}});
 #else
-    passed = sival::wafersort::csr::BitFieldWriteReadTest256WithReport(
-        {{reg_ptr}},
-        {{field_bp}},
-        {{field_bw}},
-        curr_test_idx,
-        "{{field}}",
-        {{ip_index}});
+  result = sival::wafersort::csr::BitFieldWriteReadTest256(
+      {{reg_ptr}},
+      {{field_bp}},
+      {{field_bw}},
+      "{{field}}",
+      {{ip_index}});
 #endif
 {% else %}
 #ifndef ENABLE_LOGGING
-    passed = sival::wafersort::csr::BitFieldWriteReadTest32WithReport(
-        {{reg_ptr}},
-        {{field_bp}},
-        {{field_bw}},
-        curr_test_idx,
-        nullptr,
-        {{ip_index}});
+  result = sival::wafersort::csr::BitFieldWriteReadTest32(
+      {{reg_ptr}},
+      {{field_bp}},
+      {{field_bw}},
+      nullptr,
+      {{ip_index}});
 #else
-    passed = sival::wafersort::csr::BitFieldWriteReadTest32WithReport(
-        {{reg_ptr}},
-        {{field_bp}},
-        {{field_bw}},
-        curr_test_idx,
-        "{{field}}",
-        {{ip_index}});
+  result = sival::wafersort::csr::BitFieldWriteReadTest32(
+      {{reg_ptr}},
+      {{field_bp}},
+      {{field_bw}},
+      "{{field}}",
+      {{ip_index}});
 #endif
 {% endif %}
-#else
-    WS_LOG_INFO("Testing {{field}} (0x%llx)",
-                (unsigned long long)curr_test_idx);
-    passed = fw::testing::{{function_name}}({{reg_ptr}},
-                        {{field_bp}},
-                        {{field_bw}});
-    WS_LOG_INFO("  %s", passed ? "PASS" : "FAIL");
-#endif
+  if (!result.passed) {
+    return result;
   }
-  if (!passed) {
-#ifndef ENABLE_WAFERSORT_GPIO
-    fw::testing::TestFail((uint64_t)0xDEAD000000000000 | curr_test_idx);
-#endif
-    return false;
-  }
+

--- a/src/etched_peakrdl_cheader/templates/rw_readwrite_test.c
+++ b/src/etched_peakrdl_cheader/templates/rw_readwrite_test.c
@@ -1,6 +1,9 @@
   // Write-Read from {{field}} bit field
   curr_test_idx = (uint64_t)test_idx | (uint64_t){{test_idx}};
   if(!ignorer->ShouldSkipTestIndex(curr_test_idx)) {
+#ifdef ENABLE_WAFERSORT_GPIO
+    sival::wafersort::TestProgressGpio(curr_test_idx & 0xFF);
+#endif
     passed = fw::testing::{{function_name}}({{reg_ptr}},
                         {{field_bp}},
                         {{field_bw}});

--- a/src/etched_peakrdl_cheader/templates/rw_test_lib_header.h
+++ b/src/etched_peakrdl_cheader/templates/rw_test_lib_header.h
@@ -2,7 +2,8 @@
 
 #include <cstdint>
 #include "fw/soc/sohu/sohu_chip_csr.h"
+#include "sival/wafersort/sival_helper.h"
 
 namespace {{namespace}} {
-  bool RwTest(volatile {{struct_type_name}}&, uint64_t);
+  sival::wafersort::TestResult RwTest(volatile {{struct_type_name}}&);
 

--- a/src/etched_peakrdl_cheader/templates/rw_test_lib_header.h
+++ b/src/etched_peakrdl_cheader/templates/rw_test_lib_header.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include "fw/soc/sohu/sohu_chip_csr.h"
+#include "sival/wafersort/csr/csr_test_utils.h"
 #include "sival/wafersort/sival_helper.h"
 
 namespace {{namespace}} {

--- a/src/etched_peakrdl_cheader/templates/rw_test_lib_header.h
+++ b/src/etched_peakrdl_cheader/templates/rw_test_lib_header.h
@@ -6,5 +6,6 @@
 #include "sival/wafersort/sival_helper.h"
 
 namespace {{namespace}} {
+  void RunAll(sival::wafersort::TestRunner& runner,
+              volatile {{struct_type_name}}&);
   sival::wafersort::TestResult RwTest(volatile {{struct_type_name}}&);
-

--- a/src/etched_peakrdl_cheader/templates/rw_test_registers_header.c
+++ b/src/etched_peakrdl_cheader/templates/rw_test_registers_header.c
@@ -1,5 +1,6 @@
 {% for dependency in deps %}
 {{dependency}}{% endfor %}
+#include "fw/app/csr_access_test/csr_test_ignorer.h"
 #include "fw/soc/sohu/sohu_chip_csr.h"
 {% if hasRegOrRegFile %}#include "fw/testing/bit_field_test.h"
 #include "fw/testing/testing.h"

--- a/src/etched_peakrdl_cheader/templates/rw_test_registers_header.c
+++ b/src/etched_peakrdl_cheader/templates/rw_test_registers_header.c
@@ -1,11 +1,11 @@
 {% for dependency in deps %}
 {{dependency}}{% endfor %}
 #include "fw/soc/sohu/sohu_chip_csr.h"
-#include "fw/app/csr_access_test/csr_test_ignorer.h"
 {% if hasRegOrRegFile %}#include "fw/testing/bit_field_test.h"
 #include "fw/testing/testing.h"
 #include "fw/utils/csr_descriptor_helper.h"
 #include "fw/utils/log.h"
+#include "sival/wafersort/csr/csr_test_utils.h"
 #ifndef WS_LOG_INFO
 #ifndef ENABLE_LOGGING
 #define WS_LOG_INFO(...) \
@@ -15,7 +15,5 @@
 #define WS_LOG_INFO(...) LOG_INFO_BLOCKING(__VA_ARGS__)
 #endif
 #endif
-#ifdef ENABLE_WAFERSORT_GPIO
-#include "sival/wafersort/csr/csr_test_utils.h"
-#endif
 {% endif %}
+

--- a/src/etched_peakrdl_cheader/templates/rw_test_registers_header.c
+++ b/src/etched_peakrdl_cheader/templates/rw_test_registers_header.c
@@ -5,4 +5,7 @@
 {% if hasRegOrRegFile %}#include "fw/testing/bit_field_test.h"
 #include "fw/testing/testing.h"
 #include "fw/utils/csr_descriptor_helper.h"
+#ifdef ENABLE_WAFERSORT_GPIO
+#include "sival/wafersort/sival_helper.h"
+#endif
 {% endif %}

--- a/src/etched_peakrdl_cheader/templates/rw_test_registers_header.c
+++ b/src/etched_peakrdl_cheader/templates/rw_test_registers_header.c
@@ -5,7 +5,17 @@
 {% if hasRegOrRegFile %}#include "fw/testing/bit_field_test.h"
 #include "fw/testing/testing.h"
 #include "fw/utils/csr_descriptor_helper.h"
+#include "fw/utils/log.h"
+#ifndef WS_LOG_INFO
+#ifndef ENABLE_LOGGING
+#define WS_LOG_INFO(...) \
+  do {                   \
+  } while (0)
+#else
+#define WS_LOG_INFO(...) LOG_INFO_BLOCKING(__VA_ARGS__)
+#endif
+#endif
 #ifdef ENABLE_WAFERSORT_GPIO
-#include "sival/wafersort/sival_helper.h"
+#include "sival/wafersort/csr/csr_test_utils.h"
 #endif
 {% endif %}


### PR DESCRIPTION
## Summary
- Generate `RunAll(TestRunner&)` entrypoint for wafersort CSR tests
- Continue on failures + split libs support
- Add CsrTestIgnorer mechanism for skip lists
- Fix unused variable warning for registers with no testable R/W fields
- Refactor CSR tests to return TestResult instead of bool

## Status
Draft PR to preserve changes for future regeneration work.

## Related
- sw PR: https://github.com/etched-ai/sw/pull/9544